### PR TITLE
refactor!: rename `TextDecoderDecodeOptions` to `TextDecodeOptions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ const { read, written } = encoder.encodeInto(input, output);
 
 The `TextDecoder` class decodes UTF-8 byte sequences into strings.
 
-#### `decode(input?: BufferSource, options?: TextDecoderDecodeOptions)`
+#### `decode(input?: BufferSource, options?: TextDecodeOptions)`
 
 Decodes UTF-8 bytes from the given `BufferSource` into a string.
 

--- a/src/text_decoder.ts
+++ b/src/text_decoder.ts
@@ -37,7 +37,7 @@ export interface TextDecoderOptions {
 }
 
 /** Options for the {@linkcode TextDecoder.decode} method. */
-export interface TextDecoderDecodeOptions {
+export interface TextDecodeOptions {
   /**
    * If true, indicates that the data being decoded is part of a larger stream.
    * This allows the decoder to handle incomplete byte sequences appropriately.
@@ -100,7 +100,7 @@ export class TextDecoder {
    * @throws if the input is not a BufferSource.
    * @throws if fatal is true and an invalid byte sequence is encountered.
    */
-  decode(input?: BufferSource, options?: TextDecoderDecodeOptions): string {
+  decode(input?: BufferSource, options?: TextDecodeOptions): string {
     const stream = options?.stream ?? false;
     let bytes = toUint8Array(input);
 


### PR DESCRIPTION
Breaking changes are introduced by this PR. The `TextDecoderDecodeOptions` type is now named `TextDecodeOptions`, to align with the naming conventions used in TypeScript's `lib.dom.d.ts` file.